### PR TITLE
Fix: Read on-chain state directly to determine signature mode

### DIFF
--- a/frontend/src/contexts/Web3AuthContext.jsx
+++ b/frontend/src/contexts/Web3AuthContext.jsx
@@ -275,55 +275,7 @@ export const Web3AuthProvider = ({ children }) => {
     getPrivateKey,
   };
 
-  // Show error state if initialization failed
-  if (initError) {
-    return (
-      <Web3AuthContext.Provider value={value}>
-        <div style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          minHeight: '100vh',
-          color: 'white',
-          fontSize: '18px',
-          flexDirection: 'column',
-          gap: '20px',
-          padding: '20px',
-          textAlign: 'center'
-        }}>
-          <div>❌ Web3Auth Initialization Error</div>
-          <div style={{ fontSize: '14px', opacity: 0.8, maxWidth: '600px' }}>
-            {initError}
-          </div>
-          <div style={{ fontSize: '12px', opacity: 0.6 }}>
-            Check the console for more details
-          </div>
-        </div>
-      </Web3AuthContext.Provider>
-    );
-  }
-
-  // Show loading state while initializing
-  if (isLoading) {
-    return (
-      <Web3AuthContext.Provider value={value}>
-        <div style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          minHeight: '100vh',
-          color: 'white',
-          fontSize: '18px',
-          flexDirection: 'column',
-          gap: '20px'
-        }}>
-          <div>🔄 Initializing Web3Auth...</div>
-          <div style={{ fontSize: '14px', opacity: 0.8 }}>This may take a few seconds</div>
-        </div>
-      </Web3AuthContext.Provider>
-    );
-  }
-
+  // Don't block rendering - let the app handle loading states
   return (
     <Web3AuthContext.Provider value={value}>
       {children}

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -40,6 +40,10 @@ export const P256_ACCOUNT_FACTORY_ABI = [
 ]
 
 export const P256_ACCOUNT_ABI = [
+  // Core account functions
+  'function owner() view returns (address)',
+  'function qx() view returns (bytes32)',
+  'function qy() view returns (bytes32)',
   'function execute(address dest, uint256 value, bytes calldata func) external',
   'function executeBatch(address[] calldata dest, uint256[] calldata value, bytes[] calldata func) external',
   'function enableTwoFactor() external',

--- a/scripts/check-account-state.js
+++ b/scripts/check-account-state.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+
+async function main() {
+  const accountAddress = process.argv[2] || '0xa68aC8C74F2AC44A0071C4D943cd02DF2687318b';
+  
+  // Use Sepolia RPC
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL || 'https://rpc.sepolia.org');
+  
+  const accountABI = [
+    'function owner() view returns (address)',
+    'function qx() view returns (bytes32)',
+    'function qy() view returns (bytes32)',
+    'function twoFactorEnabled() view returns (bool)',
+  ];
+  
+  const contract = new ethers.Contract(accountAddress, accountABI, provider);
+  
+  console.log('📋 Checking account state for:', accountAddress);
+  console.log('');
+  
+  try {
+    const [owner, qx, qy, twoFactorEnabled] = await Promise.all([
+      contract.owner(),
+      contract.qx(),
+      contract.qy(),
+      contract.twoFactorEnabled(),
+    ]);
+    
+    console.log('✅ On-chain state:');
+    console.log('  Owner:', owner);
+    console.log('  qx:', qx);
+    console.log('  qy:', qy);
+    console.log('  twoFactorEnabled:', twoFactorEnabled);
+    console.log('');
+    
+    const hasPasskey = qx !== '0x0000000000000000000000000000000000000000000000000000000000000000';
+    console.log('📊 Computed values:');
+    console.log('  hasPasskey:', hasPasskey);
+    console.log('  Expected signature mode:', !hasPasskey || !twoFactorEnabled ? 'OWNER-ONLY (65 bytes)' : 'PASSKEY + OWNER (WebAuthn + 65 bytes)');
+    console.log('');
+    
+    // Check if signature from logs would work
+    if (process.argv[3] && process.argv[4]) {
+      const hash = process.argv[3];
+      const signature = process.argv[4];
+      
+      console.log('🔍 Verifying signature from logs:');
+      console.log('  Hash:', hash);
+      console.log('  Signature:', signature);
+      
+      const recoveredAddress = ethers.recoverAddress(hash, signature);
+      console.log('  Recovered address:', recoveredAddress);
+      console.log('  Contract owner:', owner);
+      console.log('  Addresses match:', recoveredAddress.toLowerCase() === owner.toLowerCase());
+    }
+  } catch (error) {
+    console.error('❌ Error reading contract:', error.message);
+  }
+}
+
+main().catch(console.error);
+


### PR DESCRIPTION
## Problem

After enabling 2FA and passkey, transactions were failing with **AA24 signature error** ("Invalid signature"). The frontend was sending an owner-only signature (65 bytes) when the contract expected a passkey + owner signature (2FA mode).

### Root Cause

The frontend was using **stale/cached** `accountInfo` that didn't reflect the actual on-chain state:
- **On-chain state**: `qx != 0`, `qy != 0`, `twoFactorEnabled = true` → Contract expects 2FA signature
- **Frontend cached state**: `hasPasskey = false` or `twoFactorEnabled = false` → Frontend sends owner-only signature
- **Result**: Signature validation fails with AA24 error

## Solution

### 1. Read on-chain state directly before every transaction

```javascript
// Check if account is deployed
const accountCode = await sdk.provider.getCode(accountAddress)
const isActuallyDeployed = accountCode !== '0x'

if (isActuallyDeployed) {
  // Read directly from contract - bypass all caching
  const accountContract = new ethers.Contract(
    accountAddress,
    ['function qx() view returns (bytes32)',
     'function qy() view returns (bytes32)',
     'function twoFactorEnabled() view returns (bool)'],
    sdk.provider
  )
  
  const [qx, qy, twoFactorEnabled] = await Promise.all([
    accountContract.qx(),
    accountContract.qy(),
    accountContract.twoFactorEnabled(),
  ])
  
  // Use these values to determine signature mode
  const hasPasskey = qx !== '0x0000...'
  const isOwnerOnly = !hasPasskey || !twoFactorEnabled
}
```

### 2. Add missing ABI functions

Added `owner()`, `qx()`, `qy()` to `P256_ACCOUNT_ABI` - these were missing and causing "account.qx is not a function" errors.

### 3. Improve error handling

Show helpful error message when passkey is required but not found on device, explaining that passkeys are device-specific and stored in the device's secure enclave.

### 4. Remove Web3Auth loading screen

Removed the blocking loading UI for better UX - app now renders immediately while Web3Auth initializes in background.

## Changes

- ✅ `frontend/src/components/TransactionSender.jsx`: Read on-chain state directly before signing
- ✅ `frontend/src/lib/constants.js`: Add missing `owner()`, `qx()`, `qy()` to ABI
- ✅ `frontend/src/contexts/Web3AuthContext.jsx`: Remove initial loading screen
- ✅ `scripts/check-account-state.js`: Add debug script to verify on-chain state

## Testing

Verified with account `0xa68aC8C74F2AC44A0071C4D943cd02DF2687318b` on Sepolia:

```bash
cast call 0xa68aC8C74F2AC44A0071C4D943cd02DF2687318b "qx()(bytes32)" --rpc-url ...
# 0xb57963d175e50cdef7d5d4d7ab15d8ef2de38dfb0c6bca7dcf42b05ce2c2a7e2

cast call 0xa68aC8C74F2AC44A0071C4D943cd02DF2687318b "twoFactorEnabled()(bool)" --rpc-url ...
# true
```

Frontend now correctly detects:
- ✅ Account is deployed
- ✅ Has passkey configured
- ✅ 2FA is enabled
- ✅ Signature mode: **🔐 PASSKEY + OWNER (2FA)**

## Impact

- Fixes AA24 signature validation errors
- Ensures frontend always uses correct signature mode based on actual on-chain state
- Improves UX with better error messages and faster initial load

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author