### PR TITLE
feat: Add wallet menu with rename and remove functionality

### DIFF
--- a/frontend/src/styles/HomeScreen.css
+++ b/frontend/src/styles/HomeScreen.css
@@ -622,3 +622,224 @@
   cursor: not-allowed;
 }
 
+.btn-danger {
+  background: #dc2626;
+  color: white;
+  border: none;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #b91c1c;
+  transform: translateY(-1px);
+}
+
+/* Wallet Menu Dropdown */
+.wallet-menu-container {
+  position: relative;
+}
+
+.wallet-menu-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: white;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 160px;
+  z-index: 100;
+  overflow: hidden;
+}
+
+.menu-item {
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  background: white;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  transition: background 0.2s ease;
+}
+
+.menu-item:hover {
+  background: #f9fafb;
+}
+
+.menu-item-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.rename-item {
+  color: #374151;
+}
+
+.rename-item .menu-item-icon {
+  color: #374151;
+}
+
+.delete-item {
+  color: #dc2626;
+}
+
+.delete-item .menu-item-icon {
+  color: #dc2626;
+}
+
+.delete-item:hover {
+  background: #fef2f2;
+}
+
+/* Edit Modal Styles */
+.edit-modal .modal-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.modal-icon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #374151;
+  flex-shrink: 0;
+}
+
+.edit-modal .modal-header h2 {
+  flex: 1;
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #000;
+}
+
+.wallet-info-section {
+  margin-top: 16px;
+  padding: 12px 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+.info-label {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.info-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #000;
+}
+
+.network-info {
+  font-weight: 500;
+}
+
+.network-icon {
+  width: 24px;
+  height: 24px;
+  background: #3b82f6;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 12px;
+}
+
+.address-info {
+  font-family: 'Courier New', monospace;
+}
+
+/* Delete Modal Styles */
+.delete-modal {
+  max-width: 400px;
+}
+
+.delete-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 24px 24px 0;
+  border-bottom: none;
+}
+
+.delete-modal .modal-body {
+  padding: 24px;
+  padding-top: 32px;
+}
+
+.delete-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #000;
+  margin: 0 0 16px 0;
+  text-align: center;
+  line-height: 1.3;
+}
+
+.delete-description {
+  font-size: 16px;
+  color: #6b7280;
+  margin: 0 0 32px 0;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.delete-modal-actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.delete-btn-cancel {
+  flex: 1;
+  padding: 16px 24px;
+  background: #f3f4f6;
+  color: #374151;
+  border: none;
+  border-radius: 50px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.delete-btn-cancel:hover {
+  background: #e5e7eb;
+}
+
+.delete-btn-confirm {
+  flex: 1;
+  padding: 16px 24px;
+  background: #000;
+  color: white;
+  border: 2px solid #000;
+  border-radius: 50px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.delete-btn-confirm:hover {
+  background: #1f1f1f;
+  border-color: #1f1f1f;
+}
+


### PR DESCRIPTION
## Summary

Implements a three-dot menu on each wallet item in the home screen with rename and remove functionality.

## Features Added

### 1. Wallet Menu Dropdown
- Three-dot menu button on each wallet item
- Dropdown menu with two options:
  - **Rename** - Opens edit modal
  - **Remove** - Opens delete confirmation
- Click-outside handler to close menu

### 2. Edit Wallet Name Modal
- Clean modal design with:
  - Editable wallet name field
  - Network information (Sepolia)
  - Wallet address with identicon
  - Cancel and Save buttons
- Changes persist to localStorage

### 3. Delete Confirmation Modal
- Confirmation dialog with:
  - Clear warning message
  - Helpful text about re-adding later
  - Pill-shaped Cancel and Confirm buttons
- Removes wallet from localStorage on confirmation

## Technical Changes

**Files Modified:**
- `frontend/src/screens/HomeScreen.jsx`
  - Added new imports: `useRef`, `HiPencil`, `HiTrash`
  - Added state management for menu and modals
  - Implemented handler functions for menu, rename, and delete
  - Added menu dropdown and two modals to UI
  
- `frontend/src/styles/HomeScreen.css`
  - Added styles for wallet menu dropdown
  - Added styles for edit modal with info sections
  - Added styles for delete confirmation modal
  - Added pill-shaped button styles

## Screenshots

### Menu Dropdown
![Menu](https://github.com/user-attachments/assets/...)

### Edit Name Modal
![Edit](https://github.com/user-attachments/assets/...)

### Delete Confirmation
![Delete](https://github.com/user-attachments/assets/...)

## Testing

- [x] Menu opens/closes correctly
- [x] Click outside closes menu
- [x] Rename modal shows correct wallet info
- [x] Wallet name updates persist to localStorage
- [x] Delete confirmation works correctly
- [x] Wallet removal persists to localStorage
- [x] UI matches design mockups

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author