### PR TITLE
feat: Implement two-line wallet dropdown with name and address

### DIFF
--- a/frontend/src/components/WalletDropdown.jsx
+++ b/frontend/src/components/WalletDropdown.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { Identicon } from '../utils/identicon.jsx'
+import '../styles/WalletDropdown.css'
+
+const WalletDropdown = ({ wallets, selectedWallet, onWalletChange, formatAddress }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef(null)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen])
+
+  const handleSelect = (wallet) => {
+    onWalletChange(wallet)
+    setIsOpen(false)
+  }
+
+  return (
+    <div className="wallet-dropdown-container" ref={dropdownRef}>
+      {/* Selected Wallet Display */}
+      <div 
+        className="wallet-dropdown-trigger"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <Identicon address={selectedWallet.address} size={32} className="wallet-icon-small" />
+        <div className="wallet-dropdown-info">
+          <div className="wallet-dropdown-name">{selectedWallet.name}</div>
+          <div className="wallet-dropdown-address">{formatAddress(selectedWallet.address)}</div>
+        </div>
+        <span className={`dropdown-arrow ${isOpen ? 'open' : ''}`}>▼</span>
+      </div>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div className="wallet-dropdown-menu">
+          {wallets.map((wallet) => (
+            <div
+              key={wallet.id}
+              className={`wallet-dropdown-item ${wallet.id === selectedWallet.id ? 'selected' : ''}`}
+              onClick={() => handleSelect(wallet)}
+            >
+              <Identicon address={wallet.address} size={32} className="wallet-icon-small" />
+              <div className="wallet-dropdown-info">
+                <div className="wallet-dropdown-name">{wallet.name}</div>
+                <div className="wallet-dropdown-address">{formatAddress(wallet.address)}</div>
+              </div>
+              {wallet.id === selectedWallet.id && (
+                <span className="checkmark">✓</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default WalletDropdown
+

--- a/frontend/src/screens/SendTransactionScreen.jsx
+++ b/frontend/src/screens/SendTransactionScreen.jsx
@@ -5,6 +5,7 @@ import { useWeb3Auth } from '../contexts/Web3AuthContext'
 import { useNetwork } from '../contexts/NetworkContext'
 import { Identicon } from '../utils/identicon.jsx'
 import NetworkSelector from '../components/NetworkSelector'
+import WalletDropdown from '../components/WalletDropdown'
 import '../styles/SendTransactionScreen.css'
 
 function SendTransactionScreen({ wallet, onBack, onHome, credential, accountConfig, onLogout }) {
@@ -29,9 +30,7 @@ function SendTransactionScreen({ wallet, onBack, onHome, credential, accountConf
     }
   }, [wallet])
 
-  const handleWalletChange = (e) => {
-    const walletId = e.target.value
-    const newWallet = wallets.find(w => w.id === walletId)
+  const handleWalletChange = (newWallet) => {
     if (newWallet) {
       setSelectedWallet(newWallet)
     }
@@ -67,21 +66,12 @@ function SendTransactionScreen({ wallet, onBack, onHome, credential, accountConf
           </button>
 
           {/* Wallet Selector Dropdown */}
-          <div className="wallet-selector-dropdown">
-            <Identicon address={selectedWallet.address} size={32} className="wallet-icon-small" />
-            <select
-              value={selectedWallet.id}
-              onChange={handleWalletChange}
-              className="wallet-dropdown"
-            >
-              {wallets.map((w) => (
-                <option key={w.id} value={w.id}>
-                  {w.name} ({formatAddress(w.address)})
-                </option>
-              ))}
-            </select>
-            <span className="dropdown-arrow">▼</span>
-          </div>
+          <WalletDropdown
+            wallets={wallets}
+            selectedWallet={selectedWallet}
+            onWalletChange={handleWalletChange}
+            formatAddress={formatAddress}
+          />
 
           <NetworkSelector />
         </div>

--- a/frontend/src/screens/WalletDetailScreen.jsx
+++ b/frontend/src/screens/WalletDetailScreen.jsx
@@ -11,6 +11,7 @@ import Header from '../components/Header'
 import SubHeader from '../components/SubHeader'
 import ReceiveModal from '../components/ReceiveModal'
 import NetworkSelector from '../components/NetworkSelector'
+import WalletDropdown from '../components/WalletDropdown'
 import '../styles/WalletDetailScreen.css'
 import logo from '../assets/logo.svg'
 
@@ -48,9 +49,7 @@ function WalletDetailScreen({ wallet, onBack, onHome, onSettings, onSend, onLogo
     }
   }, [wallet])
 
-  const handleWalletChange = (e) => {
-    const walletId = e.target.value
-    const newWallet = wallets.find(w => w.id === walletId)
+  const handleWalletChange = (newWallet) => {
     if (newWallet) {
       setSelectedWallet(newWallet)
       // Notify parent component if callback is provided
@@ -226,21 +225,12 @@ function WalletDetailScreen({ wallet, onBack, onHome, onSettings, onSend, onLogo
           </button>
 
           {/* Wallet Selector Dropdown */}
-          <div className="wallet-selector-dropdown">
-            <Identicon address={selectedWallet.address} size={32} className="wallet-icon-small" />
-            <select
-              value={selectedWallet.id}
-              onChange={handleWalletChange}
-              className="wallet-dropdown"
-            >
-              {wallets.map((w) => (
-                <option key={w.id} value={w.id}>
-                  {w.name} ({formatAddress(w.address)})
-                </option>
-              ))}
-            </select>
-            <span className="dropdown-arrow">▼</span>
-          </div>
+          <WalletDropdown
+            wallets={wallets}
+            selectedWallet={selectedWallet}
+            onWalletChange={handleWalletChange}
+            formatAddress={formatAddress}
+          />
 
           <NetworkSelector />
         </div>

--- a/frontend/src/styles/WalletDropdown.css
+++ b/frontend/src/styles/WalletDropdown.css
@@ -1,0 +1,180 @@
+/* Wallet Dropdown Container */
+.wallet-dropdown-container {
+  position: relative;
+  min-width: 280px;
+}
+
+/* Dropdown Trigger (Selected Wallet) */
+.wallet-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  height: 52px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.wallet-dropdown-trigger:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.wallet-dropdown-trigger .wallet-icon-small {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.wallet-dropdown-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.wallet-dropdown-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wallet-dropdown-address {
+  font-size: 11px;
+  color: #6b7280;
+  font-family: 'Courier New', monospace;
+  line-height: 1.2;
+}
+
+.dropdown-arrow {
+  font-size: 8px;
+  color: #6b7280;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.dropdown-arrow.open {
+  transform: rotate(180deg);
+}
+
+/* Dropdown Menu */
+.wallet-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  z-index: 1000;
+  max-height: 300px;
+  overflow-y: auto;
+  animation: slideDown 0.2s ease;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Dropdown Item */
+.wallet-dropdown-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.wallet-dropdown-item:last-child {
+  border-bottom: none;
+}
+
+.wallet-dropdown-item:hover {
+  background: #f9fafb;
+}
+
+.wallet-dropdown-item.selected {
+  background: #f0f9ff;
+}
+
+.wallet-dropdown-item .wallet-icon-small {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.wallet-dropdown-item .wallet-dropdown-info {
+  flex: 1;
+}
+
+.checkmark {
+  color: #3b82f6;
+  font-size: 16px;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+/* Scrollbar Styling */
+.wallet-dropdown-menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.wallet-dropdown-menu::-webkit-scrollbar-track {
+  background: #f3f4f6;
+  border-radius: 8px;
+}
+
+.wallet-dropdown-menu::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+  border-radius: 8px;
+}
+
+.wallet-dropdown-menu::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .wallet-dropdown-container {
+    min-width: 200px;
+  }
+
+  .wallet-dropdown-trigger {
+    padding: 6px 12px;
+    height: 44px;
+  }
+
+  .wallet-dropdown-name {
+    font-size: 12px;
+  }
+
+  .wallet-dropdown-address {
+    font-size: 10px;
+  }
+
+  .wallet-dropdown-item {
+    padding: 10px 12px;
+  }
+}
+


### PR DESCRIPTION
## 🎨 Overview

This PR implements a custom wallet dropdown component that displays wallet information in a two-line layout (name on first line, address on second line) instead of the previous single-line format.

## ✨ Changes

### New Components
- **WalletDropdown.jsx** - Custom dropdown component with two-line layout
- **WalletDropdown.css** - Styling for the custom dropdown

### Updated Screens
- **WalletDetailScreen.jsx** - Now uses WalletDropdown component
- **SendTransactionScreen.jsx** - Now uses WalletDropdown component

## 🎯 Features

✅ **Two-line display**:
- Line 1: Wallet name (bold, 13px)
- Line 2: Wallet address (monospace, 11px, gray)

✅ **Visual enhancements**:
- Wallet identicon (colorful avatar)
- Checkmark (✓) for selected wallet
- Smooth dropdown animation
- Hover effects
- Click-outside-to-close functionality

✅ **Responsive design**:
- Works on desktop and mobile devices
- Proper scrolling for long wallet lists

## 📸 Screenshots

The dropdown now displays wallet information in a cleaner, more readable format with the name and address on separate lines.

## 🧪 Testing

- [x] Tested on WalletDetailScreen
- [x] Tested on SendTransactionScreen
- [x] Verified dropdown opens/closes correctly
- [x] Verified wallet selection updates properly
- [x] Verified click-outside-to-close works
- [x] Verified visual styling matches design
- [x] No console errors
- [x] Hot module replacement works correctly

## 📝 Notes

- Replaced native `<select>` elements with custom React component for better control over styling
- Updated `handleWalletChange` functions to accept wallet object directly instead of event object
- Consistent component used across all screens for maintainability

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author