### PR TITLE
feat: Unify native ETH and ERC20 token display layout

### DIFF
--- a/frontend/src/assets/tokens/eth.svg
+++ b/frontend/src/assets/tokens/eth.svg
@@ -1,21 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<!-- Creator: CorelDRAW 2019 (64-Bit) -->
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="100%" height="100%" version="1.1" shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality" fill-rule="evenodd" clip-rule="evenodd"
-viewBox="0 0 784.37 1277.39"
- xmlns:xlink="http://www.w3.org/1999/xlink"
- xmlns:xodm="http://www.corel.com/coreldraw/odm/2003">
- <g id="Layer_x0020_1">
-  <metadata id="CorelCorpID_0Corel-Layer"/>
-  <g id="_1421394342400">
-   <g>
-    <polygon fill="#343434" fill-rule="nonzero" points="392.07,0 383.5,29.11 383.5,873.74 392.07,882.29 784.13,650.54 "/>
-    <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,0 -0,650.54 392.07,882.29 392.07,472.33 "/>
-    <polygon fill="#3C3C3B" fill-rule="nonzero" points="392.07,956.52 387.24,962.41 387.24,1263.28 392.07,1277.38 784.37,724.89 "/>
-    <polygon fill="#8C8C8C" fill-rule="nonzero" points="392.07,1277.38 392.07,956.52 -0,724.89 "/>
-    <polygon fill="#141414" fill-rule="nonzero" points="392.07,882.29 784.13,650.54 392.07,472.33 "/>
-    <polygon fill="#393939" fill-rule="nonzero" points="0,650.54 392.07,882.29 392.07,472.33 "/>
-   </g>
-  </g>
- </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 417">
+  <polygon fill="#343434" points="127.9611,0 125.1661,9.5 125.1661,285.168 127.9611,287.958 255.9231,212.32"/>
+  <polygon fill="#8C8C8C" points="127.962,0 0,212.32 127.962,287.959 127.962,154.158"/>
+  <polygon fill="#3C3C3B" points="127.9611,312.1866 126.3861,314.1066 126.3861,412.3056 127.9611,416.9066 255.9991,236.5866"/>
+  <polygon fill="#8C8C8C" points="127.962,416.9052 127.962,312.1852 0,236.5852"/>
+  <polygon fill="#141414" points="127.9611,287.9577 255.9211,212.3207 127.9611,154.1587"/>
+  <polygon fill="#393939" points="0.0009,212.3208 127.9609,287.9578 127.9609,154.1588"/>
 </svg>

--- a/frontend/src/components/SignatureConfirmationDialog.jsx
+++ b/frontend/src/components/SignatureConfirmationDialog.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { ethers } from 'ethers'
 import { useNetwork } from '../contexts/NetworkContext'
+import { ethIcon } from '../lib/constants'
 import { decodeCallData } from '../utils/callDataDecoder'
 
 /**
@@ -223,23 +224,36 @@ function SignatureConfirmationDialog({
               }}>
                 {token
                   ? amount ? ethers.formatUnits(amount, token.decimalsFromChain || token.decimals) : '0'
-                  : `${amount ? ethers.formatEther(amount) : '0'} ETH`
+                  : amount ? ethers.formatEther(amount) : '0'
                 }
               </div>
-              {token && (
-                <div style={{ marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.8rem', color: '#aaa' }}>
-                    {token.icon && (
+              <div style={{ marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.8rem', color: '#aaa' }}>
+                  {token ? (
+                    <>
+                      {token.icon && (
+                        <img
+                          src={token.icon}
+                          alt={token.symbol}
+                          style={{ width: '16px', height: '16px', borderRadius: '50%' }}
+                        />
+                      )}
+                      <span>{token.name} ({token.symbol})</span>
+                    </>
+                  ) : (
+                    <>
                       <img
-                        src={token.icon}
-                        alt={token.symbol}
-                        style={{ width: '16px', height: '16px', borderRadius: '50%' }}
+                        src={ethIcon}
+                        alt="ETH"
+                        style={{ width: '16px', height: '16px' }}
                       />
-                    )}
-                    <span>{token.name} ({token.symbol})</span>
-                  </div>
+                      <span>Ether (ETH)</span>
+                    </>
+                  )}
+                </div>
 
-                  {/* Token Contract Address - Creative Badge Style */}
+                {/* Token Contract Address - Creative Badge Style (only for ERC20 tokens) */}
+                {token && (
                   <div
                     onClick={() => openExplorer(token.address)}
                     style={{
@@ -273,8 +287,8 @@ function SignatureConfirmationDialog({
                       <path d="M12 8.66667V12.6667C12 13.0203 11.8595 13.3594 11.6095 13.6095C11.3594 13.8595 11.0203 14 10.6667 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V5.33333C2 4.97971 2.14048 4.64057 2.39052 4.39052C2.64057 4.14048 2.97971 4 3.33333 4H7.33333M10 2H14M14 2V6M14 2L6.66667 9.33333" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                     </svg>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           )}
 

--- a/frontend/src/components/TransactionSender.jsx
+++ b/frontend/src/components/TransactionSender.jsx
@@ -8,7 +8,7 @@ import { ethers } from 'ethers'
 import { buildSendEthUserOp, getUserOpHash, signUserOperation, signUserOperationOwnerOnly, packAccountGasLimits, packGasFees, encodeExecute } from '../lib/userOperation'
 import { getUserFriendlyMessage, getSuggestedAction, isRetryableError } from '../lib/errors'
 import { formatPublicKeyForContract } from '../lib/accountManager'
-import { SUPPORTED_TOKENS, ERC20_ABI } from '../lib/constants'
+import { SUPPORTED_TOKENS, ERC20_ABI, ethIcon } from '../lib/constants'
 import '../styles/TransactionSender.css'
 
 function TransactionSender({ accountAddress, credential, accountConfig, onSignatureRequest }) {
@@ -980,16 +980,7 @@ function TransactionSender({ accountAddress, credential, accountConfig, onSignat
           ) : (
             <>
               <div className="token-icon">
-                <svg viewBox="0 0 784.37 1277.39" xmlns="http://www.w3.org/2000/svg">
-                  <g fill="#343434" fillRule="nonzero">
-                    <path d="m392.07 0-8.57 29.11v844.63l8.57 8.55 392.06-231.75z" fillOpacity=".6"/>
-                    <path d="m392.07 0-392.07 650.54 392.07 231.75v-435.68z"/>
-                    <path d="m392.07 956.52-4.83 5.89v300.87l4.83 14.1 392.3-552.49z" fillOpacity=".6"/>
-                    <path d="m392.07 1277.38v-320.86l-392.07-231.75z"/>
-                    <path d="m392.07 882.29 392.06-231.75-392.06-178.21z" fillOpacity=".2"/>
-                    <path d="m0 650.54 392.07 231.75v-409.96z" fillOpacity=".6"/>
-                  </g>
-                </svg>
+                <img src={ethIcon} alt="ETH" />
               </div>
               <div className="token-details">
                 <div className="token-name">Ether</div>
@@ -1011,16 +1002,7 @@ function TransactionSender({ accountAddress, credential, accountConfig, onSignat
               onClick={() => handleTokenSelect(null)}
             >
               <div className="token-icon">
-                <svg viewBox="0 0 784.37 1277.39" xmlns="http://www.w3.org/2000/svg" width="24" height="24">
-                  <g fill="#343434" fillRule="nonzero">
-                    <path d="m392.07 0-8.57 29.11v844.63l8.57 8.55 392.06-231.75z" fillOpacity=".6"/>
-                    <path d="m392.07 0-392.07 650.54 392.07 231.75v-435.68z"/>
-                    <path d="m392.07 956.52-4.83 5.89v300.87l4.83 14.1 392.3-552.49z" fillOpacity=".6"/>
-                    <path d="m392.07 1277.38v-320.86l-392.07-231.75z"/>
-                    <path d="m392.07 882.29 392.06-231.75-392.06-178.21z" fillOpacity=".2"/>
-                    <path d="m0 650.54 392.07 231.75v-409.96z" fillOpacity=".6"/>
-                  </g>
-                </svg>
+                <img src={ethIcon} alt="ETH" />
               </div>
               <div className="token-dropdown-details">
                 <div className="token-dropdown-name">Ether</div>

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -91,6 +91,7 @@ export const ERC20_ABI = [
 ]
 
 // Import token icons
+import ethIcon from '../assets/tokens/eth.svg'
 import linkIcon from '../assets/tokens/link.svg'
 import pyusdIcon from '../assets/tokens/pyusd.svg'
 import uniIcon from '../assets/tokens/uni.svg'
@@ -107,6 +108,9 @@ import enaIcon from '../assets/tokens/ena.svg'
 import usdeIcon from '../assets/tokens/usde.svg'
 import xautIcon from '../assets/tokens/xaut.svg'
 import paxgIcon from '../assets/tokens/paxg.svg'
+
+// Export ETH icon for use in components
+export { ethIcon }
 
 // Supported ERC-20 tokens by network
 export const SUPPORTED_TOKENS = {

--- a/frontend/src/screens/SignatureConfirmationScreen.jsx
+++ b/frontend/src/screens/SignatureConfirmationScreen.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import Header from '../components/Header'
 import { useWeb3Auth } from '../contexts/Web3AuthContext'
 import { useNetwork } from '../contexts/NetworkContext'
+import { ethIcon } from '../lib/constants'
 import NetworkSelector from '../components/NetworkSelector'
 import { Identicon } from '../utils/identicon.jsx'
 import { decodeCallData } from '../utils/callDataDecoder'
@@ -156,23 +157,36 @@ function SignatureConfirmationScreen({
                   <div className="amount-display">
                     {token
                       ? amount ? ethers.formatUnits(amount, token.decimalsFromChain || token.decimals) : '0'
-                      : `${amount ? ethers.formatEther(amount) : '0'} ETH`
+                      : amount ? ethers.formatEther(amount) : '0'
                     }
                   </div>
-                  {token && (
-                    <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#6b7280' }}>
-                        {token.icon && (
+                  <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '14px', color: '#6b7280' }}>
+                      {token ? (
+                        <>
+                          {token.icon && (
+                            <img
+                              src={token.icon}
+                              alt={token.symbol}
+                              style={{ width: '18px', height: '18px', borderRadius: '50%' }}
+                            />
+                          )}
+                          <span>{token.name} ({token.symbol})</span>
+                        </>
+                      ) : (
+                        <>
                           <img
-                            src={token.icon}
-                            alt={token.symbol}
-                            style={{ width: '18px', height: '18px', borderRadius: '50%' }}
+                            src={ethIcon}
+                            alt="ETH"
+                            style={{ width: '18px', height: '18px' }}
                           />
-                        )}
-                        <span>{token.name} ({token.symbol})</span>
-                      </div>
+                          <span>Ether (ETH)</span>
+                        </>
+                      )}
+                    </div>
 
-                      {/* Token Contract Address - Creative Badge Style */}
+                    {/* Token Contract Address - Creative Badge Style (only for ERC20 tokens) */}
+                    {token && (
                       <div
                         onClick={() => openExplorer(token.address)}
                         style={{
@@ -204,8 +218,8 @@ function SignatureConfirmationScreen({
                           <path d="M12 8.66667V12.6667C12 13.0203 11.8595 13.3594 11.6095 13.6095C11.3594 13.8595 11.0203 14 10.6667 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V5.33333C2 4.97971 2.14048 4.64057 2.39052 4.39052C2.64057 4.14048 2.97971 4 3.33333 4H7.33333M10 2H14M14 2V6M14 2L6.66667 9.33333" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                         </svg>
                       </div>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

This PR unifies the display layout for native ETH and ERC20 tokens, creating a consistent user experience across all token types.

## Changes

### Display Layout
- **Before**: Native ETH showed `0.014396 ETH` (with "ETH" appended to amount)
- **After**: Native ETH shows `0.014396` (number only, matching ERC20 tokens)
- Token information (icon + name/symbol) now displays below the amount for both ETH and ERC20 tokens
- Contract address badge only shows for ERC20 tokens (not for native ETH)

### Code Improvements
- Replaced inline ETH SVG code with imported icon from `assets/tokens/eth.svg`
- Updated `eth.svg` to use cleaner, simpler icon design
- Centralized ETH icon import/export in `constants.js`

### Files Modified
- `frontend/src/assets/tokens/eth.svg` - Updated to new ETH icon design
- `frontend/src/lib/constants.js` - Added ethIcon import and export
- `frontend/src/screens/SignatureConfirmationScreen.jsx` - Use imported ethIcon
- `frontend/src/components/SignatureConfirmationDialog.jsx` - Use imported ethIcon
- `frontend/src/components/TransactionSender.jsx` - Use imported ethIcon in selector and dropdown

## Screenshots

Native ETH now displays with the same consistent layout as ERC20 tokens:
- Amount: `0.014396` (just the number)
- Token Info: ETH icon + "Ether (ETH)" (displayed below)
- No contract address badge (since native ETH doesn't have a contract address)

## Testing

- [ ] Verify native ETH displays correctly in signature confirmation screens
- [ ] Verify ERC20 tokens still display correctly
- [ ] Verify ETH icon appears in token selector and dropdown
- [ ] Verify contract address badge only shows for ERC20 tokens

## Related Issues

N/A - UI/UX improvement for consistency

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author