### PR TITLE
feat: add network health status indicator

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -4,6 +4,7 @@ import { IoCopyOutline, IoCheckmark, IoOpenOutline } from 'react-icons/io5'
 import { useWeb3Auth } from '../contexts/Web3AuthContext'
 import { useNetwork } from '../contexts/NetworkContext'
 import { Identicon } from '../utils/identicon.jsx'
+import NetworkHealthStatus from './NetworkHealthStatus'
 import '../styles/Header.css'
 import logo from '../assets/logo.svg'
 
@@ -69,6 +70,7 @@ const Header = ({
         <img src={logo} alt="Ethaura Logo" className="brand-logo" />
       </div>
       <div className="header-right">
+        <NetworkHealthStatus />
         {userInfo && (
           <div className="profile-menu-container" ref={menuRef}>
             <div

--- a/frontend/src/components/NetworkHealthStatus.jsx
+++ b/frontend/src/components/NetworkHealthStatus.jsx
@@ -1,0 +1,161 @@
+/**
+ * Network Health Status Component
+ * Displays network sync status, block number, and last sync time
+ * Similar to the design shown in the reference image
+ */
+
+import { useState, useRef, useEffect } from 'react'
+import { useNetwork } from '../contexts/NetworkContext'
+import { useNetworkHealth } from '../hooks/useNetworkHealth'
+import { getNetworkIcon } from '../utils/network'
+import '../styles/NetworkHealthStatus.css'
+
+const NetworkHealthStatus = () => {
+  const { networkInfo, availableNetworks } = useNetwork()
+  const healthData = useNetworkHealth()
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef(null)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  // Format last sync time
+  const getLastSyncText = () => {
+    if (!healthData.lastSync) return 'Never'
+    
+    const now = Date.now()
+    const diff = now - healthData.lastSync
+    const seconds = Math.floor(diff / 1000)
+    
+    if (seconds < 60) return 'less than a minute'
+    if (seconds < 120) return '1 minute ago'
+    if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`
+    if (seconds < 7200) return '1 hour ago'
+    return `${Math.floor(seconds / 3600)} hours ago`
+  }
+
+  // Format block number with commas
+  const formatBlockNumber = (num) => {
+    if (!num) return '-'
+    return num.toLocaleString()
+  }
+
+  return (
+    <div className="network-health-container" ref={dropdownRef}>
+      <button
+        className="network-health-button"
+        onClick={() => setIsOpen(!isOpen)}
+        title="Network Health Status"
+      >
+        {/* Status indicator dot */}
+        <div className={`status-dot ${healthData.isLoading ? 'loading' : healthData.isHealthy ? 'healthy' : 'error'}`} />
+
+        {/* Activity/heartbeat icon */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="health-icon"
+        >
+          <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="network-health-dropdown">
+          <div className="network-health-header">
+            <h3>Network Status</h3>
+          </div>
+
+          <div className="network-health-list">
+            {/* Sepolia - Active Network with Real Data */}
+            {networkInfo.chainId === 11155111 && (
+              <div className="network-health-item active">
+                <div className="network-health-left">
+                  <img
+                    src={getNetworkIcon(11155111)}
+                    alt="Sepolia"
+                    className="network-health-icon"
+                  />
+                  <span className="network-health-name">Sepolia</span>
+                </div>
+                <div className="network-health-middle">
+                  <div className="network-health-sync">
+                    <span className="network-health-label">Last sync</span>
+                    <span className="network-health-value">{getLastSyncText()}</span>
+                  </div>
+                  <div className="network-health-block">
+                    <span className="network-health-label">Block</span>
+                    <span className="network-health-value">{formatBlockNumber(healthData.blockNumber)}</span>
+                  </div>
+                </div>
+                <div className="network-health-right">
+                  <div className={`network-health-status ${healthData.isHealthy ? 'healthy' : 'error'}`} />
+                </div>
+              </div>
+            )}
+
+            {/* Other Networks - Placeholder for Future Development */}
+            {availableNetworks
+              .filter(network => network.chainId !== 11155111)
+              .map(network => (
+                <div
+                  key={network.chainId}
+                  className={`network-health-item ${networkInfo.chainId === network.chainId ? 'active' : 'placeholder'}`}
+                >
+                  <div className="network-health-left">
+                    <img
+                      src={getNetworkIcon(network.chainId)}
+                      alt={network.name}
+                      className="network-health-icon"
+                    />
+                    <span className="network-health-name">{network.name}</span>
+                  </div>
+                  <div className="network-health-middle">
+                    <div className="network-health-sync">
+                      <span className="network-health-label">Last sync</span>
+                      <span className="network-health-value placeholder-text">Coming soon</span>
+                    </div>
+                    <div className="network-health-block">
+                      <span className="network-health-label">Block</span>
+                      <span className="network-health-value placeholder-text">-</span>
+                    </div>
+                  </div>
+                  <div className="network-health-right">
+                    <div className="network-health-status placeholder" />
+                  </div>
+                </div>
+              ))}
+          </div>
+
+          {healthData.error && (
+            <div className="network-health-error">
+              <span className="error-icon">⚠️</span>
+              <span className="error-text">{healthData.error}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NetworkHealthStatus
+

--- a/frontend/src/components/NetworkSelector.jsx
+++ b/frontend/src/components/NetworkSelector.jsx
@@ -1,13 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNetwork } from '../contexts/NetworkContext';
+import { getNetworkIcon } from '../utils/network';
 import '../styles/NetworkSelector.css';
-
-// Import network icons
-import ethereumIcon from '../assets/networks/ethereum.png';
-import sepoliaIcon from '../assets/networks/sepolia.png';
-import optimismIcon from '../assets/networks/optimism.png';
-import polygonIcon from '../assets/networks/polygon.png';
-import arbitrumIcon from '../assets/networks/arbitrum.png';
 
 const NetworkSelector = () => {
   const { networkInfo, availableNetworks, switchNetwork } = useNetwork();
@@ -48,24 +42,6 @@ const NetworkSelector = () => {
         return '#FF0420';
       default:
         return '#6B7280';
-    }
-  };
-
-  // Get network icon based on chainId
-  const getNetworkIcon = (chainId) => {
-    switch (chainId) {
-      case 11155111: // Sepolia
-        return sepoliaIcon;
-      case 1: // Ethereum
-        return ethereumIcon;
-      case 137: // Polygon
-        return polygonIcon;
-      case 42161: // Arbitrum
-        return arbitrumIcon;
-      case 10: // Optimism
-        return optimismIcon;
-      default:
-        return ethereumIcon;
     }
   };
 

--- a/frontend/src/hooks/useNetworkHealth.js
+++ b/frontend/src/hooks/useNetworkHealth.js
@@ -1,0 +1,69 @@
+/**
+ * Hook to monitor network health status
+ * Fetches block number and sync status from RPC provider
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { useNetwork } from '../contexts/NetworkContext'
+
+export function useNetworkHealth() {
+  const { networkInfo } = useNetwork()
+  const [healthData, setHealthData] = useState({
+    blockNumber: null,
+    lastSync: null,
+    isHealthy: false,
+    isLoading: true,
+    error: null,
+  })
+
+  const fetchNetworkHealth = useCallback(async () => {
+    if (!networkInfo?.rpcUrl) {
+      setHealthData(prev => ({
+        ...prev,
+        isLoading: false,
+        error: 'No RPC URL configured',
+      }))
+      return
+    }
+
+    try {
+      const provider = new ethers.JsonRpcProvider(networkInfo.rpcUrl)
+      const blockNumber = await provider.getBlockNumber()
+      const now = Date.now()
+
+      setHealthData({
+        blockNumber,
+        lastSync: now,
+        isHealthy: true,
+        isLoading: false,
+        error: null,
+      })
+    } catch (error) {
+      console.error('Failed to fetch network health:', error)
+      setHealthData(prev => ({
+        ...prev,
+        isHealthy: false,
+        isLoading: false,
+        error: error.message,
+      }))
+    }
+  }, [networkInfo?.rpcUrl])
+
+  // Fetch on mount and when network changes
+  useEffect(() => {
+    fetchNetworkHealth()
+  }, [fetchNetworkHealth])
+
+  // Poll every 12 seconds (average block time)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchNetworkHealth()
+    }, 12000)
+
+    return () => clearInterval(interval)
+  }, [fetchNetworkHealth])
+
+  return healthData
+}
+

--- a/frontend/src/styles/NetworkHealthStatus.css
+++ b/frontend/src/styles/NetworkHealthStatus.css
@@ -1,0 +1,322 @@
+/* Network Health Status Component */
+.network-health-container {
+  position: relative;
+}
+
+/* Health Button */
+.network-health-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.network-health-button:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.network-health-button:active {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+/* Health Icon */
+.health-icon {
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
+.network-health-button:hover .health-icon {
+  opacity: 1;
+}
+
+/* Status Dot Indicator */
+.status-dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  z-index: 1;
+}
+
+.status-dot.healthy {
+  background: #10B981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.status-dot.error {
+  background: #EF4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
+}
+
+.status-dot.loading {
+  background: #6B7280;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+/* Pulse Animation for Loading State */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Dropdown */
+.network-health-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 420px;
+  background: white;
+  border: 1px solid #E5E5E5;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  z-index: 1000;
+  overflow: hidden;
+  animation: slideDown 0.2s ease;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.network-health-header {
+  padding: 16px 20px;
+  border-bottom: 1px solid #E5E5E5;
+}
+
+.network-health-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1F2937;
+}
+
+/* Network List */
+.network-health-list {
+  padding: 8px 0;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+/* Network Item */
+.network-health-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  gap: 16px;
+  transition: background 0.15s ease;
+}
+
+.network-health-item:hover {
+  background: #F9FAFB;
+}
+
+.network-health-item.active {
+  background: #F0F9FF;
+}
+
+.network-health-item.placeholder {
+  opacity: 0.6;
+}
+
+/* Left Section - Network Icon and Name */
+.network-health-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 120px;
+}
+
+.network-health-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.network-health-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1F2937;
+  white-space: nowrap;
+}
+
+/* Middle Section - Sync Info and Block */
+.network-health-middle {
+  display: flex;
+  gap: 24px;
+  flex: 1;
+}
+
+.network-health-sync,
+.network-health-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.network-health-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: #6B7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.network-health-value {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1F2937;
+}
+
+.network-health-value.placeholder-text {
+  color: #9CA3AF;
+  font-style: italic;
+}
+
+/* Right Section - Status Indicator */
+.network-health-right {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.network-health-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.network-health-status.healthy {
+  background: #10B981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.network-health-status.error {
+  background: #EF4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
+}
+
+.network-health-status.placeholder {
+  background: #D1D5DB;
+}
+
+/* Error Message */
+.network-health-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  background: #FEF2F2;
+  border-top: 1px solid #FEE2E2;
+  color: #991B1B;
+  font-size: 12px;
+}
+
+.error-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.error-text {
+  flex: 1;
+  line-height: 1.4;
+}
+
+/* Scrollbar Styling */
+.network-health-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.network-health-list::-webkit-scrollbar-track {
+  background: #F9FAFB;
+}
+
+.network-health-list::-webkit-scrollbar-thumb {
+  background: #D1D5DB;
+  border-radius: 3px;
+}
+
+.network-health-list::-webkit-scrollbar-thumb:hover {
+  background: #9CA3AF;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .network-health-dropdown {
+    min-width: 360px;
+    right: -20px;
+  }
+
+  .network-health-button {
+    width: 36px;
+    height: 36px;
+  }
+
+  .network-health-item {
+    padding: 10px 16px;
+  }
+
+  .network-health-middle {
+    gap: 16px;
+  }
+
+  .network-health-name {
+    font-size: 13px;
+  }
+
+  .network-health-value {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .network-health-dropdown {
+    min-width: 320px;
+    max-width: calc(100vw - 40px);
+  }
+
+  .network-health-middle {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .network-health-sync,
+  .network-health-block {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .network-health-label::after {
+    content: ':';
+  }
+}
+

--- a/frontend/src/utils/network.js
+++ b/frontend/src/utils/network.js
@@ -2,6 +2,13 @@
  * Network utility functions
  */
 
+// Import network icons
+import ethereumIcon from '../assets/networks/ethereum.png'
+import sepoliaIcon from '../assets/networks/sepolia.png'
+import optimismIcon from '../assets/networks/optimism.png'
+import polygonIcon from '../assets/networks/polygon.png'
+import arbitrumIcon from '../assets/networks/arbitrum.png'
+
 /**
  * Get network name from chain ID
  * @param {number} chainId - The chain ID
@@ -23,24 +30,24 @@ export function getNetworkName(chainId) {
 }
 
 /**
- * Get network icon/color from chain ID
+ * Get network icon from chain ID
  * @param {number} chainId - The chain ID
- * @returns {string} Network icon (emoji or symbol)
+ * @returns {string} Network icon image path
  */
 export function getNetworkIcon(chainId) {
   const icons = {
-    1: '●',
-    11155111: '●',
-    17000: '●',
-    137: '◆',
-    80001: '◆',
-    42161: '▲',
-    421614: '▲',
-    10: '🔴',
-    11155420: '🔴',
+    1: ethereumIcon,
+    11155111: sepoliaIcon,
+    17000: ethereumIcon,
+    137: polygonIcon,
+    80001: polygonIcon,
+    42161: arbitrumIcon,
+    421614: arbitrumIcon,
+    10: optimismIcon,
+    11155420: optimismIcon,
   }
-  
-  return icons[chainId] || '●'
+
+  return icons[chainId] || ethereumIcon
 }
 
 /**


### PR DESCRIPTION
- Add NetworkHealthStatus component with activity icon and status dot
- Display real-time network health for Sepolia testnet
- Show placeholder status for other networks (Ethereum, Optimism, Polygon, Arbitrum)
- Add useNetworkHealth hook to fetch block number and sync status
- Poll RPC every 12 seconds for updates
- Integrate health indicator in Header component
- Refactor network icon utility to use centralized image imports
- Update NetworkSelector to use shared getNetworkIcon utility

Features:
- Activity/heartbeat icon with colored status dot (green/red/gray)
- Dropdown showing network status with last sync time and block number
- Responsive design with smooth animations
- Auto-refresh every 12 seconds
- Error handling with user-friendly messages