### PR TITLE
Fix portfolio distribution race condition

### DIFF
--- a/frontend/src/screens/HomeScreen.jsx
+++ b/frontend/src/screens/HomeScreen.jsx
@@ -88,10 +88,20 @@ function HomeScreen({ onWalletClick, onAddWallet, onCreateWallet, onSend, onLogo
 
         console.log(`🚀 Starting background preload for ${wallets.length} wallets`)
 
-        // Preload data for all wallets in background
-        await walletDataCache.preloadMultipleWallets(wallets, networkInfo.name, tokenService, txService)
+        // Preload data for all wallets in background with progressive updates
+        // The callback will be called after each wallet is loaded, updating the portfolio incrementally
+        await walletDataCache.preloadMultipleWallets(
+          wallets,
+          networkInfo.name,
+          tokenService,
+          txService,
+          () => {
+            // Progressive update: re-aggregate portfolio after each wallet loads
+            aggregatePortfolioData()
+          }
+        )
 
-        // After preload, aggregate portfolio data
+        // Final aggregation after all wallets are loaded
         aggregatePortfolioData()
       } catch (error) {
         console.error('Failed to start preload:', error)


### PR DESCRIPTION
## Problem

The Portfolio Distribution panel on the home screen sometimes showed "No assets yet. Add wallets to see your portfolio." even when wallets with assets existed.

### Root Cause

Race condition in the data loading flow:

1. `preloadMultipleWallets()` used `setTimeout` to stagger wallet data requests but returned immediately (undefined)
2. `aggregatePortfolioData()` was called right after awaiting `preloadMultipleWallets()`, but the cache was still empty
3. Portfolio aggregation ran before any wallet data was loaded into the cache

## Solution

### Changes Made

1. **Made `preloadMultipleWallets()` async and return a Promise**
   - Now properly waits for all wallet preload operations to complete
   - Uses `Promise.all()` to track all staggered requests
   - Maintains 500ms delay between requests to avoid rate limiting

2. **Added progressive portfolio updates**
   - Added optional `onWalletLoaded` callback parameter
   - Portfolio updates incrementally as each wallet loads (better UX)
   - Final aggregation after all wallets complete

3. **Error resilience**
   - Failed wallet loads don't block other wallets from loading
   - Each promise resolves even on error

### Benefits

✅ Fixes the race condition - Portfolio aggregation now waits for wallet data to be cached
✅ Progressive updates - Portfolio appears incrementally as each wallet loads
✅ Maintains staggering - Still uses 500ms delays between requests to avoid rate limiting
✅ Error resilient - Failed wallet loads don't block other wallets

## Testing

- [ ] Navigate to home screen with existing wallets
- [ ] Verify Portfolio Distribution loads correctly
- [ ] Verify portfolio updates progressively as wallets load
- [ ] Test with multiple wallets
- [ ] Test with network switching

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author