### PR TITLE
feat: Add transaction deadline setting for swaps (Issue #110)

### DIFF
--- a/frontend/src/components/DeadlineSelector.jsx
+++ b/frontend/src/components/DeadlineSelector.jsx
@@ -1,0 +1,160 @@
+import { useState, useEffect } from 'react'
+import { Clock, AlertTriangle } from 'lucide-react'
+import '../styles/DeadlineSelector.css'
+
+const PRESET_DEADLINES = [
+  { value: 5, label: '5 min', description: 'Quick' },
+  { value: 10, label: '10 min', description: 'Default' },
+  { value: 20, label: '20 min', description: 'Medium' },
+  { value: 30, label: '30 min', description: 'Long' },
+]
+
+const STORAGE_KEY = 'ethaura_deadline_preference'
+
+function DeadlineSelector({ value, onChange, className = '' }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [customValue, setCustomValue] = useState('')
+  const [isCustom, setIsCustom] = useState(false)
+
+  // Load saved preference on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) {
+        const savedValue = parseInt(saved, 10)
+        if (!isNaN(savedValue) && savedValue > 0) {
+          // Check if it's a preset value
+          const isPreset = PRESET_DEADLINES.some(preset => preset.value === savedValue)
+          if (!isPreset) {
+            setIsCustom(true)
+            setCustomValue(savedValue.toString())
+          }
+          onChange(savedValue)
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load deadline preference:', error)
+    }
+  }, [])
+
+  // Save preference when value changes
+  useEffect(() => {
+    if (value > 0) {
+      try {
+        localStorage.setItem(STORAGE_KEY, value.toString())
+      } catch (error) {
+        console.error('Failed to save deadline preference:', error)
+      }
+    }
+  }, [value])
+
+  const handlePresetClick = (presetValue) => {
+    setIsCustom(false)
+    setCustomValue('')
+    onChange(presetValue)
+  }
+
+  const handleCustomChange = (e) => {
+    const inputValue = e.target.value
+    setCustomValue(inputValue)
+    
+    const numValue = parseInt(inputValue, 10)
+    if (!isNaN(numValue) && numValue > 0 && numValue <= 120) {
+      setIsCustom(true)
+      onChange(numValue)
+    }
+  }
+
+  const handleCustomBlur = () => {
+    const numValue = parseInt(customValue, 10)
+    if (isNaN(numValue) || numValue <= 0) {
+      // Reset to default if invalid
+      setIsCustom(false)
+      setCustomValue('')
+      onChange(10)
+    }
+  }
+
+  const isShortDeadline = value < 5
+  const isLongDeadline = value > 30
+
+  return (
+    <div className={`deadline-selector ${className}`}>
+      <button
+        className="deadline-trigger"
+        onClick={() => setIsOpen(!isOpen)}
+        title="Transaction Deadline"
+      >
+        <Clock size={18} />
+        <span>{value} min</span>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="deadline-backdrop" onClick={() => setIsOpen(false)} />
+          <div className="deadline-dropdown">
+            <div className="deadline-header">
+              <h4>Transaction Deadline</h4>
+              <button className="deadline-close" onClick={() => setIsOpen(false)}>×</button>
+            </div>
+
+            {isShortDeadline && (
+              <div className="deadline-warning">
+                <AlertTriangle size={16} />
+                <span>Very short deadline may cause transaction to fail</span>
+              </div>
+            )}
+
+            {isLongDeadline && (
+              <div className="deadline-warning long">
+                <AlertTriangle size={16} />
+                <span>Long deadline increases risk of price changes</span>
+              </div>
+            )}
+
+            <div className="deadline-presets">
+              {PRESET_DEADLINES.map((preset) => (
+                <button
+                  key={preset.value}
+                  className={`deadline-preset ${!isCustom && value === preset.value ? 'active' : ''}`}
+                  onClick={() => handlePresetClick(preset.value)}
+                >
+                  <span className="preset-label">{preset.label}</span>
+                  {preset.description && (
+                    <span className="preset-description">{preset.description}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+
+            <div className="deadline-custom">
+              <label htmlFor="custom-deadline">Custom</label>
+              <div className="custom-input-wrapper">
+                <input
+                  id="custom-deadline"
+                  type="number"
+                  min="1"
+                  max="120"
+                  step="1"
+                  value={customValue}
+                  onChange={handleCustomChange}
+                  onBlur={handleCustomBlur}
+                  placeholder="10"
+                  className={isCustom ? 'active' : ''}
+                />
+                <span className="input-suffix">min</span>
+              </div>
+            </div>
+
+            <div className="deadline-info">
+              <p>Your transaction will revert if it is pending for more than this time.</p>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default DeadlineSelector
+

--- a/frontend/src/lib/P256AccountSDK.js
+++ b/frontend/src/lib/P256AccountSDK.js
@@ -612,6 +612,7 @@ export class P256AccountSDK {
    * @param {bigint} params.amountIn - Input amount (in token's smallest unit)
    * @param {bigint} params.amountOutMinimum - Minimum output amount (slippage protected)
    * @param {number} params.fee - Pool fee tier (500, 3000, or 10000). Default: 3000 (0.3%)
+   * @param {number} params.deadline - Unix timestamp deadline for the swap (optional)
    * @param {Object} params.passkeyCredential - Passkey credential for 2FA signing
    * @param {Function} params.signWithPasskey - Function to sign with passkey (2FA)
    * @param {string|null} params.ownerSignature - Owner signature (primary auth via Web3Auth)
@@ -627,6 +628,7 @@ export class P256AccountSDK {
     amountIn,
     amountOutMinimum,
     fee = 3000,
+    deadline = null,
     passkeyCredential,
     signWithPasskey,
     ownerSignature = null,
@@ -637,14 +639,15 @@ export class P256AccountSDK {
       // Initialize Uniswap V3 service
       const uniswapService = new UniswapV3Service(this.provider, this.chainId)
 
-      // Build approve + swap batch transaction (with allowance optimization)
+      // Build approve + swap batch transaction (with allowance optimization and deadline)
       const { targets, values, datas } = await uniswapService.buildApproveAndSwap(
         tokenIn,
         tokenOut,
         amountIn,
         amountOutMinimum,
         accountAddress,
-        fee
+        fee,
+        deadline
       )
 
       console.log('🔄 SDK executeSwap - built batch transaction:', {
@@ -656,6 +659,7 @@ export class P256AccountSDK {
         amountIn: amountIn.toString(),
         amountOutMinimum: amountOutMinimum.toString(),
         fee,
+        deadline: deadline ? new Date(deadline * 1000).toISOString() : 'default (10 min)',
         batchSize: targets.length,
       })
 

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -103,6 +103,7 @@ export const UNISWAP_V3_SWAP_ROUTER_ABI = [
   'function exactInput((bytes path, address recipient, uint256 amountIn, uint256 amountOutMinimum)) payable returns (uint256 amountOut)',
   'function exactOutputSingle((address tokenIn, address tokenOut, uint24 fee, address recipient, uint256 amountOut, uint256 amountInMaximum, uint160 sqrtPriceLimitX96)) payable returns (uint256 amountIn)',
   'function exactOutput((bytes path, address recipient, uint256 amountOut, uint256 amountInMaximum)) payable returns (uint256 amountIn)',
+  'function multicall(uint256 deadline, bytes[] calldata data) payable returns (bytes[] memory)',
 ]
 
 // Uniswap V3 QuoterV2 ABI

--- a/frontend/src/screens/SwapConfirmationScreen.jsx
+++ b/frontend/src/screens/SwapConfirmationScreen.jsx
@@ -41,6 +41,7 @@ function SwapConfirmationScreen({
     amountOut,
     quote,
     slippage,
+    deadline,
     gasEstimate,
     minimumReceived,
   } = swapDetails
@@ -161,6 +162,13 @@ function SwapConfirmationScreen({
                       </span>
                     )}
                   </span>
+                </div>
+              )}
+
+              {deadline && (
+                <div className="confirm-detail-item">
+                  <span className="confirm-detail-label">Transaction Deadline</span>
+                  <span className="confirm-detail-value">{deadline} min</span>
                 </div>
               )}
             </div>

--- a/frontend/src/screens/SwapScreen.jsx
+++ b/frontend/src/screens/SwapScreen.jsx
@@ -13,6 +13,7 @@ import Header from '../components/Header'
 import SubHeader from '../components/SubHeader'
 import TokenSelector from '../components/TokenSelector'
 import SlippageSelector from '../components/SlippageSelector'
+import DeadlineSelector from '../components/DeadlineSelector'
 import PriceImpactWarning from '../components/PriceImpactWarning'
 import PriceImpactConfirmModal from '../components/PriceImpactConfirmModal'
 import '../styles/SwapScreen.css'
@@ -44,6 +45,7 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
 
   // Settings
   const [slippage, setSlippage] = useState(0.5) // 0.5% default
+  const [deadline, setDeadline] = useState(10) // 10 minutes default
 
   // Price impact confirmation
   const [showPriceImpactModal, setShowPriceImpactModal] = useState(false)
@@ -312,6 +314,9 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
     const uniswapService = new UniswapV3Service(sdk.provider, sdk.chainId)
     const minimumReceived = uniswapService.calculateMinimumOutput(quote.amountOut, slippage)
 
+    // Calculate deadline timestamp
+    const deadlineTimestamp = Math.floor(Date.now() / 1000) + (deadline * 60)
+
     // Prepare swap details for confirmation screen
     const swapDetails = {
       tokenIn,
@@ -320,6 +325,8 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
       amountOut: quote.amountOut,
       quote,
       slippage,
+      deadline,
+      deadlineTimestamp,
       gasEstimate,
       minimumReceived,
     }
@@ -369,6 +376,9 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
         }
       })
 
+      // Calculate deadline timestamp (deadline is in minutes)
+      const deadlineTimestamp = Math.floor(Date.now() / 1000) + (deadline * 60)
+
       // Execute swap
       const result = await sdk.executeSwap({
         accountAddress: selectedWallet.address,
@@ -377,6 +387,7 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
         amountIn: amountInWei,
         amountOutMinimum,
         fee: 3000, // 0.3% fee tier
+        deadline: deadlineTimestamp,
         passkeyCredential,
         signWithPasskey,
         ownerSignature: null, // TODO: Add owner signature for 2FA if enabled
@@ -622,6 +633,7 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
           {/* Settings Bar */}
           <div className="swap-settings-bar">
             <SlippageSelector value={slippage} onChange={setSlippage} />
+            <DeadlineSelector value={deadline} onChange={setDeadline} />
           </div>
 
           {/* Swap Form Card */}
@@ -904,6 +916,10 @@ function SwapScreen({ wallet, onBack, onHome, onSettings, onLogout, onWalletChan
               <div className="sidebar-info-item">
                 <span className="sidebar-info-label">Slippage Tolerance:</span>
                 <span className="sidebar-info-value">{slippage}%</span>
+              </div>
+              <div className="sidebar-info-item">
+                <span className="sidebar-info-label">Transaction Deadline:</span>
+                <span className="sidebar-info-value">{deadline} min</span>
               </div>
               <div className="sidebar-info-item">
                 <span className="sidebar-info-label">Fee Tier:</span>

--- a/frontend/src/styles/DeadlineSelector.css
+++ b/frontend/src/styles/DeadlineSelector.css
@@ -1,0 +1,227 @@
+.deadline-selector {
+  position: relative;
+}
+
+.deadline-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.deadline-trigger:hover {
+  background: #e5e7eb;
+  border-color: #d1d5db;
+}
+
+.deadline-trigger svg {
+  color: #6b7280;
+}
+
+.deadline-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+}
+
+.deadline-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 320px;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  padding: 16px;
+}
+
+.deadline-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.deadline-header h4 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.deadline-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.deadline-close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.deadline-warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #fef3c7;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  color: #92400e;
+  font-size: 13px;
+}
+
+.deadline-warning.long {
+  background: #fef3c7;
+  border-color: #fde68a;
+  color: #92400e;
+}
+
+.deadline-warning svg {
+  flex-shrink: 0;
+  color: #f59e0b;
+}
+
+.deadline-presets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.deadline-preset {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  background: #f9fafb;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 10px 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.deadline-preset:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.deadline-preset.active {
+  background: #eff6ff;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.deadline-preset .preset-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.deadline-preset .preset-description {
+  font-size: 11px;
+  color: #6b7280;
+  text-align: center;
+}
+
+.deadline-custom {
+  margin-bottom: 12px;
+}
+
+.deadline-custom label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6b7280;
+  margin-bottom: 6px;
+}
+
+.deadline-custom .custom-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.deadline-custom .custom-input-wrapper input {
+  width: 100%;
+  background: #f9fafb;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 10px 40px 10px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #111827;
+  outline: none;
+  transition: all 0.2s;
+}
+
+.deadline-custom .custom-input-wrapper input:focus,
+.deadline-custom .custom-input-wrapper input.active {
+  background: #eff6ff;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.deadline-custom .custom-input-wrapper input::placeholder {
+  color: #9ca3af;
+}
+
+/* Remove number input arrows */
+.deadline-custom .custom-input-wrapper input::-webkit-outer-spin-button,
+.deadline-custom .custom-input-wrapper input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.deadline-custom .custom-input-wrapper input[type=number] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.deadline-custom .input-suffix {
+  position: absolute;
+  right: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6b7280;
+  pointer-events: none;
+}
+
+.deadline-info {
+  background: #f9fafb;
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.deadline-info p {
+  margin: 0;
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Summary

Implements transaction deadline setting to prevent stale transactions from being executed, as specified in issue #110.

## Changes

### New Components

**DeadlineSelector (frontend/src/components/DeadlineSelector.jsx)**
- Similar design to SlippageSelector for consistent UX
- Preset options: 5, 10 (default), 20, 30 minutes
- Custom input (1-120 minutes)
- Persists user preference to localStorage
- Warning for very short (<5 min) or long (>30 min) deadlines

### Integration

**SwapScreen.jsx**
- Added DeadlineSelector next to SlippageSelector in settings bar
- Calculates deadline timestamp and passes to swap execution
- Displays deadline in sidebar info panel

**SwapConfirmationScreen.jsx**
- Displays transaction deadline in the key details section

**uniswapService.js**
- Added `buildMulticallWithDeadline()` function
- Modified `buildApproveAndSwap()` to wrap swap calls in `multicall(uint256 deadline, bytes[] data)`

**P256AccountSDK.js**
- Added `deadline` parameter to `executeSwap()` function

**constants.js**
- Added `multicall` function to UNISWAP_V3_SWAP_ROUTER_ABI

## Technical Details

### Deadline Calculation
```javascript
deadlineTimestamp = Math.floor(Date.now() / 1000) + (minutes * 60)
```

### Uniswap V3 SwapRouter02 Multicall
The SwapRouter02 contract provides a `multicall(uint256 deadline, bytes[] calldata data)` function that:
- Checks if `block.timestamp <= deadline` before executing
- Reverts with "Transaction too old" if deadline has passed

## Acceptance Criteria

- [x] Deadline selector with presets (5, 10, 20, 30 min)
- [x] Custom deadline input (1-120 min range)
- [x] Deadline timestamp calculated correctly
- [x] Deadline passed to swap via multicall
- [x] Deadline displayed in confirmation screen
- [x] Preference persisted in localStorage

Closes #110

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author